### PR TITLE
Change variable name to `snake_case`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@
 
   docker: no
 
-  oracle-xe-test: no
+  oracle_xe_test: no
 
   proxy: no
   proxy_url: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,4 +32,4 @@
   - lineinfile: dest=/u01/app/oracle/.bashrc line="source ~/.bash_profile" state=present
 
   - include: oracle-xe-test.yml
-    when: oracle-xe-test
+    when: oracle_xe_test


### PR DESCRIPTION
### Summary

An error is thrown when running this role in Vagrant v2.0.0 and Ansible v2.4.1.0. The main reason is that an existing variable, `oracle-xe-test` is using `kebab-case` convention.

I've renamed the variable to `oracle_xe_test` (i.e. `snake_case`), and it works as expected now.

Full error message below:

```
TASK [ansible-oraclexe : file] *************************************************
fatal: [oraclexe]: FAILED! => {"failed": true, "msg": "The conditional check 'oracle-xe-test' failed. The error was: error while evaluating conditional (oracle-xe-test): Unable to look up a name or access an attribute in template string ({% if oracle-xe-test %} True {% else %} False {% endif %}).\nMake sure your variable name does not contain invalid characters like '-': unsupported operand type(s) for -: 'dict' and 'StrictUndefined'\n\nThe error appears to have been in '/vagrant/scripts/ansible/roles/ansible-oraclexe/tasks/oracle-xe-test.yml': line 3, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - file: path=/tmp/test state=directory owner=oracle group=dba\n    ^ here\n"}
        to retry, use: --limit @/vagrant/scripts/ansible/playbook.retry
```